### PR TITLE
ADD: enable automatic spacing for CJK text

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -21,6 +21,7 @@ body {
   color: $text-color;
   background-color: $background-color;
   -webkit-text-size-adjust: 100%;
+  text-spacing: auto;
 }
 
 


### PR DESCRIPTION
## Summary
- enable CSS `text-spacing: auto` on the global body styles so mixed Chinese/English text receives automatic spacing in modern browsers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6903bcb3de588328a367416fee7d1dee